### PR TITLE
added app dir to bower path

### DIFF
--- a/api_app.js
+++ b/api_app.js
@@ -21,7 +21,7 @@ app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use('/bower_components',  express.static( path.join(__dirname, '/bower_components')));
+app.use('/bower_components',  express.static( path.join(__dirname, '/app/bower_components')));
 //Set the angular folder to serve static resources
 app.use(express.static(path.join(__dirname, '/angular')));
 


### PR DESCRIPTION
The path to `bower_components` was missing the `app` path segment. Adding this fixed the resource loading problem.
