### PR TITLE
fixed angular boostrap/touch references

### DIFF
--- a/angular/index.html
+++ b/angular/index.html
@@ -9,7 +9,7 @@
     <script src="/bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="/bower_components/angular-touch/angular-touch.min.js"></script>    
     <script src="/bower_components/ng-notifications-bar/dist/ngNotificationsBar.min.js"></script>
-    <script src="/bower_components/angular-ui-bootstrap/dist/ui-bootstrap.js"></script>
+    <script src="/bower_components/angular-bootstrap/ui-bootstrap.min.js"></script>
                         
         <!-- get j-query-->
         <script src="https://code.jquery.com/jquery-2.2.3.js"></script> 

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,8 @@
     "angular-route": "1.5.x",
     "ng-notifications-bar": "0.0.16",
     "bootstrap": "3.3.x",
-    "jquery": "2.2.x"
+    "jquery": "2.2.x",
+    "angular-touch": "^1.5.8",
+    "angular-bootstrap": "^2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "angular": "^1.5.8",
     "angular-route": "^1.5.8",
     "angular-sanitize": "^1.5.8",
-    "angular-touch": "^1.5.8",
-    "angular-ui-bootstrap": "^2.1.4",
     "body-parser": "1.15.2",
     "cookie-parser": "~1.4.3",
     "express": "4.14.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "karma-chrome-launcher": "^0.2.3",
     "karma-firefox-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.8",
-    "protractor": "^3.2.2",
+    "protractor": "^3.2.2"
   },
   "scripts": {
     "postinstall": "bower install",


### PR DESCRIPTION
Hey Adam, I figured out why Angular boostrap/touch wasn't working.

First, you added the dependencies to package.json which downloaded them into `node_modules/`, but you referenced them in index.html as if they were in `bower_components/`. So I moved the dependencies to bower.json so they get downloaded in the correct location.

Second, according to the [angular-ui-bootstrap README](https://github.com/angular-ui/bootstrap#install-with-bower), you have to install `angular-bootstrap` with bower, not `angular-ui-bootstrap` for it to work. So I changed that dependency to match the install instructions and updated index.html.

Now the dependencies both seem to load correctly on the page.

A quick word about package.json vs. bower.json -- these configure two different tools, npm and bower respectively, BUT package.json has a ["postinstall" trigger](https://github.com/adamlucz90/RecordmateAngular/blob/master/package.json#L19) which will cause bower to execute _after_ you run `npm install`. So it's just conveniently chaining these two commands together for you. Packages that are used by node.js modules on the server should go in package.json, but anything you want to reference on your web page should go in bower.json.

In the case of `angular-ui-bootstrap` (package.json) vs `angular-bootstrap` (bower.json), these are the same _libraries_, but the code is structured differently. In the case of the former, a tool like webpack will be run on the server to compile `angular-ui-bootstrap` into a script with a bunch of other libraries which will then be served up to the browser, whereas in the case of the latter, you are serving up `angular-bootstrap` directly to the browser as an individual script, skipping any special compilation step altogether. 
